### PR TITLE
Add Sphinx and Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file for Sphinx projects
+version: 2
+
+
+# Set the OS, Python version and other tools you might need
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the "docs/" directory with Sphinx
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+
+# Install Python dependencies 
+python:
+  install:
+    - requirements: docs/requirements.txt
+

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,96 @@
+/* Define colors*/
+:root {
+    --nest-orange: #ff6633;
+    --nest-blue: #0E6A93;
+    --nest-dkblue: #072f42;
+    --nest-brown: #4b210c;
+
+a {color: var(--nest-orange);}
+a:hover {
+  text-decoration: underline;
+}
+
+ul.md-tabs__list li.md-tabs__item a.md-tabs__link {
+ color: #fff;
+ opacity:0.9;
+}
+a.md-tabs__link, a.md-source {
+  color: #fff;
+}
+[data-md-color-primary=orange] .md-tabs {
+  background-color: var(--nest-orange);
+ }
+
+/* To add matching styling for the header in index.html */
+div[role="main"] .md-header {
+  background-color: var(--nest-orange);
+/*  scale: 140%;
+  padding-top: 0.3rem;
+  height: 2.6rem;
+	transition: background-color .25s,color .25s,box-shadow .25s;
+	box-shadow: 0 0 .2rem rgba(0,0,0,.1),0 .2rem .4rem rgba(0,0,0,.2);
+*/
+}
+
+[data-md-color-primary="orange"] .md-header, [data-md-color-primary="orange"] .md-hero {
+  background-color: var(--nest-orange);
+}
+
+[data-md-color-primary="orange"] .md-typeset a {
+  color: var(--nest-orange);
+	background-color: #ffffff8a;
+	border-radius: 5px;
+}
+.md-nav__link:hover {
+
+	color: var(--nest-brown);
+}
+
+
+/*
+[data-md-color-primary="orange"] .md-nav__link--active, [data-md-color-primary="orange"] .md-nav__link:active {
+	color: var(--nest-orange);
+}
+
+.md-nav__extra_link{
+  color: var(--nest-orange);
+}
+
+.md-nav__link, .md-nav__link:focus{
+	color: var(--nest-orange) !important;
+}
+*/
+.md-typeset .admonition, .md-typeset .admonition.tip {
+  border-left: .2rem solid var(--nest-blue);
+  border-radius: 5px;
+}
+
+.md-typeset .admonition > .admonition-title::before, .md-typeset .admonition.important > .admonition-title::before, .md-typeset .admonition.tip > .admonition-title::before {
+  color: #fff;
+}
+.md-typeset .admonition > .admonition-title, .md-typeset .admonition.tip > .admonition-title {
+  background-color: var(--nest-blue);
+  color: #fff;
+}
+.md-typeset .admonition {
+   background-color: #fff;
+   box-shadow: 0 .125rem .25rem var(--sd-color-shadow);
+   margin-left: 17px;
+   margin-right: 15px;
+}
+.md-typeset .admonition.seealso > .admonition-title, .md-typeset .admonition.important > .admonition-title {
+   background-color: var(--nest-dkblue);
+}
+.md-typeset .admonition.seealso, .md-typeset .admonition.important {
+  border-left: .2rem solid var(--nest-dkblue);
+}
+.md-typeset .admonition.warning {
+   border-left-color: #be1717;
+}
+.md-typeset .admonition.warning > .admonition-title {
+   background-color: #be1717;
+}
+.md-typeset .admonition.danger > .admonition-title {
+   background-color: black;
+}
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,12 +40,8 @@ author = 'NEST developers'
 
 extensions = [
     "sphinx.ext.autosummary",
-    "sphinx.ext.autodoc",
-    "sphinx.ext.coverage",
-    "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
 ]
 
 
@@ -95,3 +91,9 @@ html_css_files = [
 # Custom sidebar templates, maps page names to templates.
 html_sidebars = {"**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]}
 
+intersphinx_mapping = {
+    "nestml": ("https://nestml.readthedocs.io/en/latest/", None),
+    "nest": ("https://nest-simulator.readthedocs.io/en/latest/", None),
+    "gpu": ("https://nest-gpu.readthedocs.io/en/latest/", None),
+    "neat": ("https://nest-neat.readthedocs.io/en/latest", None)
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# conf.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'NEST extension module'
+copyright = '2025, NEST developers'
+author = 'NEST developers'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autosummary",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+]
+
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+pygments_style = "manni"
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_material"
+
+html_theme_options = {
+    # Set the name of the project to appear in the navigation.
+    # Set you GA account ID to enable tracking
+    # 'google_analytics_account': 'UA-XXXXX',
+    # Specify a base_url used to generate sitemap.xml. If not
+    # specified, then no sitemap will be built.
+    "base_url": "https://nest-simulator.readthedocs.io/en/latest/",
+    "html_minify": False,
+    "html_prettify": False,
+    "css_minify": True,
+    # Set the color and the accent color
+    "color_primary": "orange",
+    "color_accent": "white",
+    "theme_color": "ff6633",
+    "master_doc": False,
+    # Set the repo location to get a badge with stats
+    "repo_url": "https://github.com/heplesser/bsshslmmodule",
+    "repo_name": "NEST Extension Module",
+    "nav_links": [{"href": "index", "internal": True, "title": "Docs home"}],
+    # Visible levels of the global TOC; -1 means unlimited
+    "globaltoc_depth": 1,
+    # If False, expand all TOC entries
+    "globaltoc_collapse": True,
+    # If True, show hidden TOC entries
+    "globaltoc_includehidden": True,
+    "version_dropdown": False,
+}
+
+html_static_path = ['_static']
+html_css_files = [
+    "custom.css"]
+
+# Custom sidebar templates, maps page names to templates.
+html_sidebars = {"**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]}
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,17 @@
+.. NEST extension module documentation master file, created by
+   sphinx-quickstart on Thu Mar 20 13:19:02 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+NEST extension module documentation
+===================================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-material


### PR DESCRIPTION
You can see the output here: https://test-bsshslmmodule.readthedocs.io/en/latest/ - this is using my fork as the source repo.

You can modify the index.rst file in docs or add new files (default is reStructured Text). 

Once this project is set up in the nest organization, we can connect it to Read the Docs with an appropriate name.